### PR TITLE
Add grid building options and persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ This project is designed to be iPhone-friendly and playable in portrait mode. On
 
 ## 🎮 Gameplay
 
-- Tap **"Roll to Explore"** to gather random resources (wood, stone, metal).
-- Click on empty squares in the grid to place a **wall (🧱)** using 1 stone.
-- Your resources are tracked and displayed.
-- Future features might include more build types, regions, quests, and vertical building.
+- Tap **"Roll to Explore"** to gather random resources with a chance for random events.
+- Build structures on the grid: **walls (🧱)**, **towers (🏰)** and **doors (🚪)**.
+- Resources and grid layout persist between sessions thanks to `localStorage`.
+- Gain experience when exploring and level up over time.
+- Undo your last placement or clear the grid entirely.
 
 ---
 
@@ -46,9 +47,7 @@ This project is designed to be iPhone-friendly and playable in portrait mode. On
 
 - Multi-floor castle building
 - Crafting system (combine resources)
-- Random events during exploration
 - Quest-based objectives
-- Save/load via localStorage
 
 ---
 

--- a/app.js
+++ b/app.js
@@ -1,14 +1,38 @@
+// constants
+const GRID_SIZE = 5;
+const RESOURCE_TYPES = { WOOD: 'wood', STONE: 'stone', METAL: 'metal' };
+const BUILDINGS = {
+  wall: { emoji: '🧱', cost: { [RESOURCE_TYPES.STONE]: 1 } },
+  tower: { emoji: '🏰', cost: { [RESOURCE_TYPES.STONE]: 2, [RESOURCE_TYPES.METAL]: 1 } },
+  door: { emoji: '🚪', cost: { [RESOURCE_TYPES.WOOD]: 1 } },
+};
+const XP_PER_LEVEL = 5;
+
 // game state
-let resources = { wood: 0, stone: 0, metal: 0 };
-let grid = Array.from({ length: 5 }, () => Array(5).fill(''));
+let resources = load('resources') || { wood: 0, stone: 0, metal: 0 };
+let grid = load('grid') || Array.from({ length: GRID_SIZE }, () => Array(GRID_SIZE).fill(''));
+let player = load('player') || { level: 1, xp: 0 };
+let history = [];
 
 // helpers
 function updateResources() {
   document.getElementById('resources').textContent =
-    `Wood: ${resources.wood} | Stone: ${resources.stone} | Metal: ${resources.metal}`;
+    `Wood: ${resources.wood} | Stone: ${resources.stone} | Metal: ${resources.metal} | Level: ${player.level}`;
+  save();
 }
 function narrate(text) {
   document.getElementById('narration').textContent = text;
+}
+
+function save() {
+  localStorage.setItem('resources', JSON.stringify(resources));
+  localStorage.setItem('grid', JSON.stringify(grid));
+  localStorage.setItem('player', JSON.stringify(player));
+}
+
+function load(key) {
+  const data = localStorage.getItem(key);
+  return data ? JSON.parse(data) : null;
 }
 
 // exploration
@@ -25,31 +49,94 @@ document.getElementById('exploreBtn').addEventListener('click', () => {
     resources.metal++;
     found = '1 Metal';
   }
-  narrate(`You rolled a ${roll} and found ${found}!`);
+
+  let msg = `You rolled a ${roll} and found ${found}!`;
+
+  const eventRoll = Math.random();
+  if (eventRoll < 0.1) {
+    const keys = Object.keys(resources).filter(k => resources[k] > 0);
+    if (keys.length) {
+      const lossKey = keys[Math.floor(Math.random() * keys.length)];
+      resources[lossKey]--;
+      msg += ` But bandits stole 1 ${lossKey}!`;
+    }
+  } else if (eventRoll > 0.9) {
+    resources.metal++;
+    msg += ' You discovered rare metal!';
+  }
+
+  player.xp++;
+  if (player.xp >= player.level * XP_PER_LEVEL) {
+    player.level++;
+    player.xp = 0;
+    msg += ` Level up! You are now level ${player.level}.`;
+  }
+
+  narrate(msg);
   updateResources();
 });
 
 // grid setup
 const gridEl = document.getElementById('grid');
+const buildSelect = document.getElementById('buildSelect');
+let selectedBuild = buildSelect.value;
+buildSelect.addEventListener('change', e => (selectedBuild = e.target.value));
+
+function canAfford(cost) {
+  return Object.keys(cost).every(r => resources[r] >= cost[r]);
+}
+
+function payCost(cost) {
+  Object.keys(cost).forEach(r => (resources[r] -= cost[r]));
+}
+
+function refundCost(cost) {
+  Object.keys(cost).forEach(r => (resources[r] += cost[r]));
+}
+
 function drawGrid() {
+  gridEl.style.setProperty('--grid-size', GRID_SIZE);
   gridEl.innerHTML = '';
-  for (let y = 0; y < 5; y++) {
-    for (let x = 0; x < 5; x++) {
+  for (let y = 0; y < GRID_SIZE; y++) {
+    for (let x = 0; x < GRID_SIZE; x++) {
       const cell = document.createElement('div');
       cell.className = 'cell';
       cell.textContent = grid[y][x] || '';
-      // click to build a wall (example)
       cell.addEventListener('click', () => {
-        if (resources.stone > 0 && !grid[y][x]) {
-          resources.stone--;
-          grid[y][x] = '🧱';
-          updateResources();
-          drawGrid();
+        if (!grid[y][x]) {
+          const building = BUILDINGS[selectedBuild];
+          if (canAfford(building.cost)) {
+            payCost(building.cost);
+            grid[y][x] = building.emoji;
+            history.push({ x, y, building });
+            cell.classList.add('selected');
+            setTimeout(() => cell.classList.remove('selected'), 200);
+            updateResources();
+            drawGrid();
+          }
         }
       });
       gridEl.appendChild(cell);
     }
   }
 }
+
+document.getElementById('undoBtn').addEventListener('click', () => {
+  const last = history.pop();
+  if (last) {
+    grid[last.y][last.x] = '';
+    refundCost(last.building.cost);
+    drawGrid();
+    updateResources();
+  }
+});
+
+document.getElementById('clearBtn').addEventListener('click', () => {
+  grid = Array.from({ length: GRID_SIZE }, () => Array(GRID_SIZE).fill(''));
+  history = [];
+  drawGrid();
+  updateResources();
+});
+
 drawGrid();
 updateResources();

--- a/index.html
+++ b/index.html
@@ -6,12 +6,24 @@
   <title>Dice & Castle</title>
   <link rel="stylesheet" href="styles.css" />
   <link rel="manifest" href="manifest.json" />
+  <link rel="apple-touch-icon" href="icon-192.png" />
 </head>
 <body>
   <h1>🛡️ Dice & Castle</h1>
   <div id="narration">Welcome, adventurer!</div>
   <button id="exploreBtn">Roll to Explore</button>
-  <div id="resources">Wood: 0 | Stone: 0 | Metal: 0</div>
+  <div id="resources">Wood: 0 | Stone: 0 | Metal: 0 | Level: 1</div>
+
+  <div id="buildControls">
+    <label for="buildSelect">Build:</label>
+    <select id="buildSelect">
+      <option value="wall">Wall 🧱</option>
+      <option value="tower">Tower 🏰</option>
+      <option value="door">Door 🚪</option>
+    </select>
+    <button id="undoBtn">Undo</button>
+    <button id="clearBtn">Clear</button>
+  </div>
 
   <h2>Your Castle</h2>
   <div id="grid"></div>

--- a/service-worker.js
+++ b/service-worker.js
@@ -4,7 +4,9 @@ const ASSETS = [
   'index.html',
   'styles.css',
   'app.js',
-  'manifest.json'
+  'manifest.json',
+  'icon-192.png',
+  'icon-512.png'
 ];
 
 self.addEventListener('install', evt =>

--- a/styles.css
+++ b/styles.css
@@ -4,9 +4,12 @@ body {
   margin: auto;
   padding: 1em;
 }
+#buildControls {
+  margin: 0.5em 0;
+}
 #grid {
   display: grid;
-  grid-template: repeat(5, 50px) / repeat(5, 50px);
+  grid-template: repeat(var(--grid-size, 5), 50px) / repeat(var(--grid-size, 5), 50px);
   gap: 2px;
   margin-top: 0.5em;
 }
@@ -16,6 +19,9 @@ body {
   align-items: center;
   justify-content: center;
   font-size: 0.8em;
+}
+.cell.selected {
+  outline: 2px solid #f00;
 }
 button {
   font-size: 1em;


### PR DESCRIPTION
## Summary
- add apple-touch icon link and building controls in `index.html`
- store resources, grid and player level in localStorage
- add random exploration events and experience system
- introduce building types with selectable controls
- allow undo and clearing the grid
- support variable grid size and update CSS for highlight
- cache icon files in service worker
- document new gameplay features in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685bfdd11abc8320b8b548b5b2a6f160