### PR TITLE
Add build cost display and enlarge grid

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 // constants
-const GRID_SIZE = 5;
+const GRID_SIZE = 8;
 const RESOURCE_TYPES = { WOOD: 'wood', STONE: 'stone', METAL: 'metal' };
 
 const CRAFTABLES = {
@@ -134,11 +134,29 @@ document.getElementById('exploreBtn').addEventListener('click', () => {
 // grid setup
 const gridEl = document.getElementById('grid');
 const buildSelect = document.getElementById('buildSelect');
+const buildCostEl = document.getElementById('buildCost');
 const craftSelect = document.getElementById('craftSelect');
 const floorSelect = document.getElementById('floorSelect');
 const addFloorBtn = document.getElementById('addFloorBtn');
 let selectedBuild = buildSelect.value;
-buildSelect.addEventListener('change', e => (selectedBuild = e.target.value));
+buildSelect.addEventListener('change', e => {
+  selectedBuild = e.target.value;
+  updateBuildCost();
+});
+
+function updateBuildCost() {
+  const building = BUILDINGS[selectedBuild];
+  if (building.cost) {
+    const costStr = Object.entries(building.cost)
+      .map(([r, n]) => `${n} ${r}`)
+      .join(', ');
+    buildCostEl.textContent = `Cost: ${costStr}`;
+  } else if (building.inventoryItem) {
+    buildCostEl.textContent = `Uses: 1 ${building.inventoryItem}`;
+  } else {
+    buildCostEl.textContent = '';
+  }
+}
 
 function populateFloors() {
   floorSelect.innerHTML = '';
@@ -252,3 +270,4 @@ document.getElementById('clearBtn').addEventListener('click', () => {
 populateFloors();
 drawGrid();
 updateResources();
+updateBuildCost();

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
       <option value="fortifiedWall">Fortified Wall</option>
       <option value="reinforcedDoor">Reinforced Door</option>
     </select>
+    <div id="buildCost"></div>
     <button id="undoBtn">Undo</button>
     <button id="clearBtn">Clear</button>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,10 @@ body {
 #buildControls {
   margin: 0.5em 0;
 }
+#buildCost {
+  font-size: 0.8em;
+  margin: 0.25em 0;
+}
 #craftControls,
 #floorControls,
 #questContainer {


### PR DESCRIPTION
## Summary
- display required resources for selected building
- style cost indicator
- expand grid to 8x8

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685dcb13b4b08320bc4951e9bc7a48aa