### PR TITLE
Add stamina and new exploration choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This project is designed to be iPhone-friendly and playable in portrait mode. On
 
 ## 🎮 Gameplay
 
-- Tap **"Roll to Explore"** to gather random resources with a chance for random events.
+- Choose a location and tap **"Explore"** to gather resources using stamina.
+- Stamina drains as you explore and automatically recovers when you sleep.
+- Sleep triggers a dice roll for good, bad, or neutral overnight events.
 - Build structures on the grid: **walls (🧱)**, **towers (🏰)** and **doors (🚪)**.
 - Resources and grid layout persist between sessions thanks to `localStorage`.
 - Gain experience when exploring and level up over time.

--- a/index.html
+++ b/index.html
@@ -11,8 +11,14 @@
 <body>
   <h1>🛡️ Dice & Castle</h1>
   <div id="narration">Welcome, adventurer!</div>
-  <button id="exploreBtn">Roll to Explore</button>
-  <div id="resources">Wood: 0 | Stone: 0 | Metal: 0 | Level: 1</div>
+  <label for="locationSelect">Location:</label>
+  <select id="locationSelect">
+    <option value="forest">Forest</option>
+    <option value="quarry">Quarry</option>
+    <option value="mine">Mine</option>
+  </select>
+  <button id="exploreBtn">Explore</button>
+  <div id="resources">Wood: 0 | Stone: 0 | Metal: 0 | Level: 1 | Stamina: 10/10</div>
 
   <div id="questContainer">
     <pre id="quests"></pre>


### PR DESCRIPTION
## Summary
- add stamina tracking and nightly sleep events
- allow exploring forest, quarry, or mine with varying costs
- show stamina on screen
- update README gameplay section

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685dcd8d78ac8320b11d8848bed2864b