### PR TITLE
Implement terrain grid and wall upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ This project is designed to be iPhone-friendly and playable in portrait mode. On
 - Choose a location and tap **"Explore"** to gather resources using stamina.
 - Stamina drains as you explore and automatically recovers when you sleep.
 - Sleep triggers a dice roll for good, bad, or neutral overnight events.
-- Build structures on the grid: **walls (🧱)**, **towers (🏰)** and **doors (🚪)**.
+- Build on a terrain grid with forests, mountains and desert tiles.
+- Place your **home (🏠)** first, then construct **wood walls (🪵)** which can be upgraded to **stone walls (🧱)**.
+- Additional structures include **farms (🌾)** and **quarries (⛏️)**.
 - Resources and grid layout persist between sessions thanks to `localStorage`.
 - Gain experience when exploring and level up over time.
 - Undo your last placement or clear the grid entirely.

--- a/index.html
+++ b/index.html
@@ -27,13 +27,11 @@
   <div id="buildControls">
     <label for="buildSelect">Build:</label>
     <select id="buildSelect">
-      <option value="wall">Wall 🧱</option>
-      <option value="tower">Tower 🏰</option>
-      <option value="door">Door 🚪</option>
-      <option value="market">Market 🏪</option>
-      <option value="barracks">Barracks 🏹</option>
-      <option value="fortifiedWall">Fortified Wall</option>
-      <option value="reinforcedDoor">Reinforced Door</option>
+      <option value="home">Home 🏠</option>
+      <option value="woodWall">Wood Wall 🪵</option>
+      <option value="stoneWall">Stone Wall 🧱</option>
+      <option value="farm">Farm 🌾</option>
+      <option value="quarry">Quarry ⛏️</option>
     </select>
     <div id="buildCost"></div>
     <button id="undoBtn">Undo</button>


### PR DESCRIPTION
## Summary
- introduce terrain types and new building options
- add home, wood wall, stone wall, farm and quarry
- restrict building placement and allow wall upgrades
- display terrain and new structures on the grid
- update README gameplay section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dd1826c8c8320956953de987c4ebf