### PR TITLE
Add daily explores with d20 rolls

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ This project is designed to be iPhone-friendly and playable in portrait mode. On
 
 ## 🎮 Gameplay
 
-- Choose a location and tap **"Explore"** to gather resources using stamina.
-- Stamina drains as you explore and automatically recovers when you sleep.
+- Choose a location and tap **"Explore"** to gather resources.
+- You can explore five times per in-game day.
+- Each exploration rolls a d20: 1 is a critical fail while 20 is a huge success.
 - Sleep triggers a dice roll for good, bad, or neutral overnight events.
 - Upgrade your **living quarters** from a humble camp to larger homes.
 - Strengthen your **walls** from earthen mounds to sturdy stone.

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <option value="mine">Mine</option>
   </select>
   <button id="exploreBtn">Explore</button>
-  <div id="resources">Wood: 0 | Stone: 0 | Metal: 0 | Level: 1 | Stamina: 10/10</div>
+  <div id="resources">Wood: 0 | Stone: 0 | Metal: 0 | Level: 1 | Explores Left: 5/5</div>
 
   <div id="questContainer">
     <pre id="quests"></pre>


### PR DESCRIPTION
## Summary
- replace stamina system with 5 explores per day
- add d20 outcome table when exploring
- update UI and save data to use new explores mechanic
- update README to describe new rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ddac478988320b8e4d86f3b24e0ae