### PR TITLE
Reduce mobile toolbar size

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,13 @@
   <link rel="apple-touch-icon" href="icon-192.png" />
 </head>
 <body>
-  <h1>🛡️ Dice & Castle</h1>
-  <button id="textBigger">A+</button>
-  <button id="textSmaller">A-</button>
+  <nav id="toolbar">
+    <h1>🛡️ Dice & Castle</h1>
+    <div>
+      <button id="textBigger">A+</button>
+      <button id="textSmaller">A-</button>
+    </div>
+  </nav>
   <div id="narration">Welcome, adventurer!</div>
   <label for="locationSelect">Location:</label>
   <select id="locationSelect">

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,19 @@ button {
   font-size: 1em;
   padding: 0.5em 1em;
 }
+#toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5em;
+}
+#toolbar h1 {
+  margin: 0;
+  font-size: 1.5em;
+}
+#toolbar button {
+  padding: 0.25em 0.5em;
+}
 #log {
   white-space: pre-wrap;
   background: #f0f0f0;


### PR DESCRIPTION
## Summary
- add a `nav` container for the title and text-size buttons
- style toolbar to be compact on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68632b6c45bc83208bc56b9a4033eddc