### PR TITLE
Add bottom navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -311,6 +311,12 @@ const upgradeQuarryBtn = document.getElementById('upgradeQuarryBtn');
 const craftCharmBtn = document.getElementById('craftCharmBtn');
 const textBiggerBtn = document.getElementById('textBigger');
 const textSmallerBtn = document.getElementById('textSmaller');
+const exploreScreen = document.getElementById('exploreScreen');
+const buildScreen = document.getElementById('buildScreen');
+const logScreen = document.getElementById('logScreen');
+const navExplore = document.getElementById('navExplore');
+const navBuild = document.getElementById('navBuild');
+const navLog = document.getElementById('navLog');
 
 function updateUI() {
   homeLevelSpan.textContent = `${HOME_UPGRADES[structures.homeLevel].name} ${HOME_UPGRADES[structures.homeLevel].emoji}`;
@@ -366,5 +372,17 @@ textSmallerBtn.addEventListener('click', () => {
   const size = parseInt(getComputedStyle(document.body).fontSize);
   document.body.style.fontSize = Math.max(12, size - 2) + 'px';
 });
+
+function showScreen(screen) {
+  exploreScreen.style.display = screen === 'explore' ? 'block' : 'none';
+  buildScreen.style.display = screen === 'build' ? 'block' : 'none';
+  logScreen.style.display = screen === 'log' ? 'block' : 'none';
+}
+
+navExplore.addEventListener('click', () => showScreen('explore'));
+navBuild.addEventListener('click', () => showScreen('build'));
+navLog.addEventListener('click', () => showScreen('log'));
+
+showScreen('explore');
 
 updateResources();

--- a/index.html
+++ b/index.html
@@ -17,31 +17,34 @@
     </div>
   </nav>
   <div id="narration">Welcome, adventurer!</div>
-  <label for="locationSelect">Location:</label>
-  <select id="locationSelect">
-    <option value="forest">Forest</option>
-    <option value="quarry">Quarry</option>
-    <option value="mine">Mine</option>
-  </select>
-  <button id="exploreBtn">Explore</button>
-  <div id="resources">Wood: 0 | Stone: 0 | Metal: 0 | Level: 1 | Explores Left: 5/5</div>
 
-  <div id="questContainer">
-    <pre id="quests"></pre>
-  </div>
-  <pre id="log"></pre>
-  <button id="craftCharmBtn">Craft Lucky Charm (2 wood)</button>
+  <section id="exploreScreen">
+    <label for="locationSelect">Location:</label>
+    <select id="locationSelect">
+      <option value="forest">Forest</option>
+      <option value="quarry">Quarry</option>
+      <option value="mine">Mine</option>
+    </select>
+    <button id="exploreBtn">Explore</button>
+    <div id="resources">Wood: 0 | Stone: 0 | Metal: 0 | Level: 1 | Explores Left: 5/5</div>
 
-  <h2>Your Settlement</h2>
-  <div id="structures">
-    <div id="homeSection">
-      Home Level: <span id="homeLevel"></span>
-      <button id="upgradeHomeBtn"></button>
+    <div id="questContainer">
+      <pre id="quests"></pre>
     </div>
-    <div id="wallsSection">
-      Walls Level: <span id="wallsLevel"></span>
-      <button id="upgradeWallsBtn"></button>
-    </div>
+  </section>
+
+  <section id="buildScreen" style="display:none;">
+    <button id="craftCharmBtn">Craft Lucky Charm (2 wood)</button>
+    <h2>Your Settlement</h2>
+    <div id="structures">
+      <div id="homeSection">
+        Home Level: <span id="homeLevel"></span>
+        <button id="upgradeHomeBtn"></button>
+      </div>
+      <div id="wallsSection">
+        Walls Level: <span id="wallsLevel"></span>
+        <button id="upgradeWallsBtn"></button>
+      </div>
     <div id="farmSection">
       Farms: <span id="farmCount"></span> (Level <span id="farmLevel"></span>)
       <button id="buildFarmBtn"></button>
@@ -52,7 +55,18 @@
       <button id="buildQuarryBtn"></button>
       <button id="upgradeQuarryBtn"></button>
     </div>
-  </div>
+    </div>
+  </section>
+
+  <section id="logScreen" style="display:none;">
+    <pre id="log"></pre>
+  </section>
+
+  <nav id="bottomNav">
+    <button id="navExplore">Explore</button>
+    <button id="navBuild">Settlement</button>
+    <button id="navLog">Log</button>
+  </nav>
 
   <script src="app.js"></script>
   <script>

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,7 @@ body {
   max-width: 480px;
   margin: auto;
   padding: 1em;
+  padding-bottom: 3.5em; /* space for bottom nav */
   font-size: 16px;
 }
 #questContainer {
@@ -35,4 +36,19 @@ button {
   margin-top: 0.5em;
   height: 6em;
   overflow-y: auto;
+}
+
+#bottomNav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+  background: #fff;
+  border-top: 1px solid #ccc;
+  padding: 0.5em 0;
+}
+#bottomNav button {
+  flex: 1;
 }


### PR DESCRIPTION
## Summary
- add Explore, Settlement and Log screens
- create fixed bottom nav and extra padding
- hide/show screens from nav buttons

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863f32571c08320a5494fef53d3e1bb